### PR TITLE
Support use from script tag in XML doc

### DIFF
--- a/src/xslt-polyfill-src.js
+++ b/src/xslt-polyfill-src.js
@@ -331,10 +331,10 @@
   }
 
   function replaceCurrentXMLDoc() {
-    const doc = new XMLSerializer().serializeToString(document);
-    loadXmlContentWithXsltWhenReady(doc, window.location.href, false).catch(
+    const xml = new XMLSerializer().serializeToString(document);
+    loadXmlContentWithXsltWhenReady(xml, window.location.href).catch(
       (err) => {
-        console.error("Error transforming current XML document:", err);
+        replaceDoc(`Error displaying XML file: ${err.message || err.toString()}`);
       }
     );
   }

--- a/test/demo_large.xml
+++ b/test/demo_large.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="demo_large.xsl"?>
 <GUIDE title="Google Common Lisp Style Guide">
+<script src="../xslt-polyfill.min.js" xmlns="http://www.w3.org/1999/xhtml"></script>
 
 
 <p>


### PR DESCRIPTION
This PR adds support for loading the polyfill directly into an XML document. If it detects that it is running in an XMLDocument then it transforms that document in place. This allows you to use it without any additional HTML document or JS.

I tested this locally with Chrome Canary with XSLT disabled and it works. See `test/demo_large.xml` for usage. Basically you just need to add this to the root element in your XML doc:

```xml
<?xml version="1.0"?>
<?xml-stylesheet type="text/xsl" href="demo.xsl" ?>
<page>
 <script src="../xslt-polyfill.min.js" xmlns="http://www.w3.org/1999/xhtml"></script>
 <message>
  Hello World.
 </message>
</page>
```
 load it from a static server in Canary and it should transform.

I tried to keep this PR as minimal as possible and follow the style of the existing code, but I would recommend a bit of a refactor here. Because we can be sure that this will only be needed in the most modern browsers, it would be good to use more modern syntax and publish it as ESM.

Fixes #4