### PR TITLE
Move puppeteer to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "node run-tests.js"
   },
   "type": "commonjs",
-  "dependencies": {
+  "devDependencies": {
     "puppeteer": "^24.37.5"
   }
 }


### PR DESCRIPTION
puppeteer is only used in run-tests.js as a headless browser test runner. It has no role in the polyfill itself and should never be pulled in as a transitive dependency by consumers.

Placing it under dependencies caused npm installs to download puppeteer and its bundled Chromium unnecessarily.