### PR TITLE
Avoid `document instanceof XMLDocument`

### DIFF
--- a/src/xslt-polyfill-src.js
+++ b/src/xslt-polyfill-src.js
@@ -979,7 +979,10 @@
     throw new Error(errorMessage);
   }
 
-  if (!nativeSupported && document instanceof XMLDocument && !xsltDontAutoloadXmlDocs) {
+  const type = document.contentType;
+  const isXml = type === "text/xml" || type === "application/xml" || type.endsWith("+xml");
+  
+  if (!nativeSupported && isXml && !xsltDontAutoloadXmlDocs) {
     if (document.readyState === 'loading') {
       document.addEventListener(
         'DOMContentLoaded',


### PR DESCRIPTION
In Gecko, application/xhtml+xml is not an XMLDocument.