### PR TITLE
src/transform.c: make the out_mime_type buffer size explicit

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -421,6 +421,10 @@ static xmlDocPtr docLoader(const xmlChar *URI, xmlDictPtr dict, int options,
   return doc;
 }
 
+// The size of the out_mime_type buffer that callers of transform() must
+// provide. Keep in sync with the allocation in src/xslt-polyfill-src.js.
+#define MIME_TYPE_BUFFER_SIZE 32
+
 // Copy of this:
 // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/xml/xslt_processor_libxslt.cc;l=319;drc=936810fb4d0e0b979b156d5325a52e5b6c40b088
 static const char *ResultMIMEType(xmlDocPtr result_doc,
@@ -437,6 +441,12 @@ static const char *ResultMIMEType(xmlDocPtr result_doc,
 
   return "application/xml";
 }
+
+// ResultMIMEType() returns one of the three literals above; the longest is
+// "application/xml".
+_Static_assert(MIME_TYPE_BUFFER_SIZE >= sizeof("application/xml"),
+               "MIME_TYPE_BUFFER_SIZE must hold the longest MIME type that "
+               "ResultMIMEType() can return.");
 
 // Adjust the HTML encoding meta tag to match Chrome's behavior.
 // Libxslt's default behavior for HTML output is to insert <meta
@@ -542,8 +552,8 @@ static void adjust_html_encoding_meta(xmlDocPtr doc, xsltStylesheetPtr style) {
  * @param xslt_content A string containing the XSLT stylesheet.
  * @param params An array of key-value pairs for XSLT parameters, terminated by
  * NULL. Example: ["param1", "'value1'", "param2", "'value2'", NULL]
- * @param out_mime_type A pointer to a buffer (at least 32 bytes) where the
- * output MIME type will be written.
+ * @param out_mime_type A pointer to a buffer of at least
+ * MIME_TYPE_BUFFER_SIZE (32) bytes where the output MIME type will be written.
  * @return A pointer to a new string containing the transformed document, or
  * NULL on error.
  */
@@ -655,8 +665,7 @@ char *transform(const char *xml_content, int xml_len, const char *xslt_content,
 
   // Determine the MIME type using the helper function
   const char *mime = ResultMIMEType(result_doc, xslt_sheet);
-  strncpy(out_mime_type, mime, 32);
-  out_mime_type[31] = '\0';
+  snprintf(out_mime_type, MIME_TYPE_BUFFER_SIZE, "%s", mime);
 
   // 6. Ensure the HTML meta tag for encoding is in the Chrome/Blink format.
   adjust_html_encoding_meta(result_doc, xslt_sheet);

--- a/src/xslt-polyfill-src.js
+++ b/src/xslt-polyfill-src.js
@@ -342,7 +342,8 @@
         xsltPtr = writeBytesToHeap(xsltBytes);
         xsltUrlPtr = writeStringToHeap(xsltUrl);
 
-        // Allocate memory for the output mime type (minimum 32 bytes).
+        // Allocate memory for the output mime type. The size must match
+        // MIME_TYPE_BUFFER_SIZE in src/transform.c.
         mimeTypePtr = WasmModule._malloc(32);
         if (!mimeTypePtr) throw new Error('Wasm malloc failed for mimeType pointer.');
         new Uint8Array(WasmModule.wasmMemory.buffer, mimeTypePtr, 32).fill(0);


### PR DESCRIPTION
## Summary

Following up on the review: **the original `strncpy` code was already correct**, and this PR no longer claims otherwise. It wrote the NUL terminator explicitly, and it's safe for a stronger reason too — `ResultMIMEType()` only ever returns one of three string literals (`"text/html"`, `"text/plain"`, `"application/xml"`), so at most 16 bytes including the terminator can ever reach a 32-byte buffer. Truncation isn't reachable, let alone an overflow. The author-controlled `xsl:output method` value only reaches `xmlStrEqual()` comparisons; it is never copied.

What's left is a small readability change. Happy to close it if you'd rather not churn this line.

## What this changes

`src/transform.c`:

1. Replaces the magic `32`, which was spelled out four times with nothing checking the copies agree: the `strncpy` bound, the `[31]` index, the `@param out_mime_type` doc comment, and the `_malloc(32)` in `src/xslt-polyfill-src.js` that allocates the buffer. It's now `MIME_TYPE_BUFFER_SIZE`.
2. Adds a `_Static_assert` that the buffer fits the longest MIME type `ResultMIMEType()` can return, so the invariant this code relies on is checked by the compiler instead of by inspection. (`_Static_assert` is the C11 keyword, so no new include.)
3. Uses `snprintf` rather than `strncpy` plus a separate terminating store, so the bound and the NUL termination are stated once instead of on two lines that have to stay in agreement. This also stops the semgrep rule from re-flagging the line.

`src/xslt-polyfill-src.js`: comment only, cross-referencing the C constant from the `_malloc` that has to match it. Since terser strips comments, this leaves the minified output unchanged.

## Behavior

No behavior change. For all three values `ResultMIMEType()` can return, `snprintf(out_mime_type, 32, "%s", mime)` writes exactly the same bytes as `strncpy(out_mime_type, mime, 32); out_mime_type[31] = '\0';`. The two would only differ for a source string of 32+ bytes, which is unreachable here.

## Testing

I did not add a truncation regression test, because one isn't constructible through the public API — the only inputs to this buffer are the three compile-time literals in `ResultMIMEType()`. The `_Static_assert` is the honest test: it breaks the build if someone later adds a longer MIME type without growing the buffer.

The three MIME values themselves are already covered, and the coverage is load-bearing rather than incidental: `XSLTProcessor output (HTML)` / `(XML)` / `(text)` / `(blank, html content)` / `(blank, non-html content)`, plus `XML Output` and `Text Output` in `test/testcase_generator.js`, exercise all three, and `transformToFragment` ends its MIME switch in ``throw new Error(`Unknown mime type ${mimeType}`)`` — so a corrupted or truncated MIME string would fail those tests loudly rather than silently.

If you'd like a test that asserts the MIME type directly (e.g. `document.contentType` on the `xml-stylesheet` path), say the word and I'll add one — I left it out because it duplicates existing coverage.

I haven't rebuilt `xslt-polyfill.min.js` or `dist/xslt-wasm.js`; happy to, or you can fold it into your next rebuild commit.
